### PR TITLE
Fix permission error when using python-daemon>=2.1

### DIFF
--- a/watcher.py
+++ b/watcher.py
@@ -72,6 +72,9 @@ class DaemonRunner(object):
         self.daemon_context = daemon.DaemonContext(umask=umask or 0,
                             working_directory=working_directory or '/',
                             uid=uid, gid=gid)
+        # python-daemon>=2.1 has initgroups=True by default but it requires root privs;
+        # older versions don't support initgroups as constructor parameter so we set it manually instead:
+        self.daemon_context.initgroups = False
         self.daemon_context.stdin  = open(stdin or '/dev/null', 'rb')
         self.daemon_context.stdout = open(stdout or '/dev/null', 'w+b')
         self.daemon_context.stderr = open(stderr or '/dev/null', 'w+b', buffering=0)


### PR DESCRIPTION
python-daemon versions 2.1 started using os.initgroups() which requires root privileges. As a result, when trying to execute watcher.py with python-daemon 2.1 installed users are presented with a permission error. This commit tries to addres that.

Based on the following code: https://github.com/ThiefMaster/maildump/commit/ea2645b1bb9c4fca5c0e8ad8185839fc26f62fe4
